### PR TITLE
Список браузеров, которые мы поддерживаем

### DIFF
--- a/browserslist
+++ b/browserslist
@@ -1,0 +1,9 @@
+# Browsers that we support
+
+ie >= 11
+edge >= 1
+last 3 chrome versions
+last 3 ff versions
+last 2 opera versions
+last 2 safari versions
+last 2 ios_saf versions


### PR DESCRIPTION
Autoprefixer автоматически ищет файл `browserslist` в корне проекта, поэтому отдельных настроек не нужно.
