### PR TITLE
Add ignore for custom properties

### DIFF
--- a/html-css.html
+++ b/html-css.html
@@ -870,12 +870,15 @@ ul >li {}
           <article class="chapter-part">
             <div class="chapter-part-col">
               <h3 id="css-units">Единицы измерения</h3>
-              <p>Единицы измерения не указаны там, где в них нет необходимости.</p>
+              <p>Единицы измерения не указаны там, где в них нет необходимости (за исключением значений кастомных свойств).</p>
             </div>
             <div class="chapter-part-col gray-bgcolor">
               <figure>
                 <pre><code class="language-css">/* Хорошо */
 .element {
+  --x: 0%;
+  --y: 0px;
+
   border: 0;
   box-shadow: 0 1px 2px #cccccc, inset 0 1px 0 #ffffff;
   margin-top: 0;


### PR DESCRIPTION
Кастомные свойства уже никуда не запрятать, и есть смысл достаточно сильных студентов учить использовать их для большего удобства разработки, читабельности и поддерживаемости кода.

Но вот это правило вставляет палки в колёса, когда кастомное свойство используется в расчётах, но при объявлении свойства надо указать нулевое значение. Линтер требует убрать размерность, а без неё `calc()` ломается.

Чтобы не приходилось выкручиваться чем-то вроде:
` --my-prop: calc(0 * 1px); `
(что крайне неудобно, особенно, если ещё и предполагается, что значение должно скриптом считываться) надо добавить иннорирование этим правилом кастомных свойств.

---

[Пулреквест в конфиг стайллинта](https://github.com/htmlacademy/stylelint-config-htmlacademy/pull/15).