### PR TITLE
Исправляет ссылку на Primer Guidelines от GitHub

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@
 * [Code Guide](http://codeguide.co) by @mdo
 * [CSS Guidelines](http://cssguidelin.es) by Harry Roberts
 * [Idiomatic CSS](https://github.com/necolas/idiomatic-css) by Nicolas Gallagher
-* [Primer Guidelines](https://styleguide.github.com/primer/principles/) by GitHub
+* [Primer Guidelines](https://primer.style/css/) by GitHub
 
 ## Лицензия
 


### PR DESCRIPTION
[Текущая ссылка](https://styleguide.github.com/primer/principles/) ведёт на 404. В Wayback Machine [последняя доступная версия страницы](https://web.archive.org/web/20201111195934/https://styleguide.github.com/primer/principles/) подсказывает в предупреждении вверху, что информация в будущем будет доступна по новому адресу: https://primer.style/css/.